### PR TITLE
Fixing a bug

### DIFF
--- a/multitv.snippet.php
+++ b/multitv.snippet.php
@@ -127,6 +127,7 @@ foreach ($tvOutput as $value) {
 	if ($rows != 'all') {
 		// output only selected rows 
 		if (!in_array($i, $rows)) {
+			$i++;
 			continue;
 		}
 	}


### PR DESCRIPTION
&rows=`2,3` not working before.
